### PR TITLE
Add ip and chart API's to the price ticker

### DIFF
--- a/src/api/ipController.ts
+++ b/src/api/ipController.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express";
+import fetch from "node-fetch";
+import { sendError, sendJSON } from "./defaultController";
+
+export const getIpDetails = async (req: Request, res: Response) => {
+  try {
+      fetch("http://api.ipstack.com/check?access_key=a9e03264eab585d224212a5edcac8fcf&format=1")
+        .then(response => response.json())
+        .then(json => {
+            sendJSON(res, json);
+        });
+  } catch (e) {
+    sendError(res, "Couldn't fetch IP data.");
+  }
+};

--- a/src/api/priceController.ts
+++ b/src/api/priceController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-
+import fetch from "node-fetch";
 import mongoose = require("mongoose");
 const Price = mongoose.model("Price");
 import { sendError, sendJSON } from "./defaultController";
@@ -29,4 +29,18 @@ const sendErrorFindingCurrency = (res: Response) => {
     res,
     "We weren't able to fetch your request, maybe check your currency input."
   );
+};
+
+export const getPriceChart = async (req: Request, res: Response) => {
+  try {
+    const filter = req.params.from ? `${req.params.from}/${req.params.till}` : ''
+    
+    fetch(`https://graphs2.coinmarketcap.com/currencies/verge/${filter}`)
+      .then(response => response.json())
+      .then(json => {
+          sendJSON(res, json);
+      });
+  } catch (e) {
+    sendError(res, "Couldn't fetch chart data.");
+  }
 };

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3,6 +3,10 @@ import { Express } from "express-serve-static-core";
 module.exports = (app: Express) => {
   import("./priceController").then(priceController => {
     app.route("/api/v1/price/:currency").get(priceController.getPriceByCurrency);
-    app.route("/api/v1/chart").get(priceController.getPriceByCurrency);
+    app.route("/api/v1/chart/(:from/:till)?").get(priceController.getPriceChart);
+  }),
+
+  import("./ipController").then(ipController => {
+    app.route("/api/v1/ip").get(ipController.getIpDetails);
   })
 };


### PR DESCRIPTION
First simple solution for getting the api used within the iOS/Android/Electron app to our own servers.
So we can swap the used API's when needed or find better solutions.